### PR TITLE
Fix garbled unicode character in generated bibtex

### DIFF
--- a/21-1342/info.json
+++ b/21-1342/info.json
@@ -7,7 +7,7 @@
         "Jeff Braga",
         "Dipam Chakraborty",
         "Kinal Mehta",
-        "Jo\u00e3o G.M. Ara\u00fajo"
+        "João G.M. Araújo"
     ],
     "emails": [
         "costa.huang@outlook.com",


### PR DESCRIPTION
The generated bib file in https://jmlr.org/papers/v23/21-1342.html is 

```
@article{JMLR:v23:21-1342,
  author  = {Shengyi Huang and Rousslan Fernand Julien Dossa and Chang Ye and Jeff Braga and Dipam Chakraborty and Kinal Mehta and JoÃ£o G.M. AraÃºjo},
  title   = {CleanRL: High-quality Single-file Implementations of Deep Reinforcement Learning Algorithms},
  journal = {Journal of Machine Learning Research},
  year    = {2022},
  volume  = {23},
  number  = {274},
  pages   = {1--18},
  url     = {http://jmlr.org/papers/v23/21-1342.html}
}
```

which displays the author's name incorrectly as `JoÃ£o G.M. AraÃºjo`, whereas the correct name of @joaogui1 would be `João G.M. Araújo`. This PR fixes this issue. 